### PR TITLE
Repaired an issue of not finding an lcg release if run from a jupyter notebook

### DIFF
--- a/dask_lxplus/cluster.py
+++ b/dask_lxplus/cluster.py
@@ -148,7 +148,7 @@ class CernCluster(HTCondorCluster):
             container_runtime = container_runtime or image_type
 
         if lcg:
-            if not re.match('^/cvmfs/sft(?:-nightlies)?.cern.ch/lcg/views/.+/python[2,3]?$', sys.executable):
+            if not re.match('^/cvmfs/sft(?:-nightlies)?.cern.ch/lcg/.+/python[2,3]?$', sys.executable):
                 raise ValueError(f"You need to have loaded the LCG environment before running the python interpreter. Current interpreter: {sys.executable}")
 
         base_class_kwargs = CernCluster._modify_kwargs(


### PR DESCRIPTION
Solution of the issue in https://github.com/cernops/dask-lxplus/issues/2.

So far, initiating the cluster worked from a python shell but not from a Jupyter notebook release because of a condition that the executable needs to be in the `.../lcg/views/` folder but the notebook executable is in `.../lcg/latest/`.